### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      HEX_API_KEY: ${{ secrets.MIREGO_HEXPM_API_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: 24.x
+          elixir-version: 1.13.x
+      - run: mix deps.get
+      - run: mix compile --docs
+      - run: mix hex.publish --yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 24.x
-          elixir-version: 1.13.x
+          otp-version: 25.x
+          elixir-version: 1.14.x
       - run: mix deps.get
       - run: mix compile --docs
       - run: mix hex.publish --yes


### PR DESCRIPTION
Let’s add a `publish` workflow like we have in our other Hex.pm package repositories.