### PR TITLE
Fix write buffer invalid events with cast_value and try/rescue

### DIFF
--- a/lib/telemetry_ui/event.ex
+++ b/lib/telemetry_ui/event.ex
@@ -2,7 +2,7 @@ defmodule TelemetryUI.Event do
   @moduledoc false
 
   @enforce_keys ~w(value time event_name tags report_as)a
-  defstruct value: 0, time: nil, event_name: nil, tags: %{}, report_as: nil
+  defstruct value: 0, time: nil, event_name: nil, tags: %{}, report_as: nil, cast_value: nil
 
   def cast_event_name(metric) do
     Enum.join(metric.name, ".")
@@ -10,5 +10,9 @@ defmodule TelemetryUI.Event do
 
   def cast_report_as(metric) do
     Keyword.get(metric.reporter_options, :report_as) || ""
+  end
+
+  def cast_reporter_cast_value(metric) do
+    Keyword.get(metric.reporter_options, :cast_value)
   end
 end

--- a/lib/telemetry_ui/metrics/metrics.ex
+++ b/lib/telemetry_ui/metrics/metrics.ex
@@ -63,7 +63,8 @@ defmodule TelemetryUI.Metrics do
   end
 
   defp id(metric) do
-    reporter_options = Jason.encode!(Enum.into(Map.get(metric, :reporter_options) || [], %{}))
+    reporter_options = Enum.reject(List.wrap(Map.get(metric, :reporter_options)), fn {_, value} -> is_function(value) end)
+    reporter_options = Jason.encode!(Map.new(reporter_options))
 
     [
       metric.description,

--- a/lib/telemetry_ui/reporter.ex
+++ b/lib/telemetry_ui/reporter.ex
@@ -43,7 +43,8 @@ defmodule TelemetryUI.Reporter do
           time: DateTime.utc_now(),
           event_name: event_name,
           tags: tags,
-          report_as: cast_report_as(metric)
+          report_as: cast_report_as(metric),
+          cast_value: cast_reporter_cast_value(metric)
         }
       )
     end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -29,6 +29,7 @@ defmodule TelemetryUI.Test.DataCase do
     end
 
     TelemetryUI.Test.Factory.bootstrap()
+    Process.sleep(1000)
     :ok
   end
 end

--- a/test/telemetry_ui/write_buffer_test.exs
+++ b/test/telemetry_ui/write_buffer_test.exs
@@ -61,6 +61,70 @@ defmodule TelemetryUI.WriteBufferTest do
       assert_receive {1.0, _, "test", %{}, 1, nil}
     end
 
+    test "resilient to invalid event" do
+      backend = %FakeBackend{max_buffer_size: 3, self: self()}
+      {:ok, _write_buffer} = WriteBuffer.start_link(name: :buffer_test, backend: backend)
+
+      buffer = [
+        %TelemetryUI.Event{
+          value: "invalid",
+          time: ~U[2020-01-01T00:00:30Z],
+          event_name: "test",
+          tags: %{},
+          report_as: nil
+        },
+        %TelemetryUI.Event{
+          value: 1,
+          time: ~U[2020-01-01T00:14:12Z],
+          event_name: "test_2",
+          tags: %{},
+          report_as: nil
+        }
+      ]
+
+      state = %WriteBuffer.State{buffer: buffer, backend: backend, timer: nil}
+
+      WriteBuffer.handle_info(:tick, state)
+
+      refute_receive {2.0, ~U[2020-01-01T00:00:00Z], "test", %{}, nil, nil}
+      assert_receive {1.0, ~U[2020-01-01T00:14:00Z], "test_2", %{}, 1, nil}
+    end
+
+    test "cast_value event" do
+      backend = %FakeBackend{max_buffer_size: 3, self: self()}
+      {:ok, _write_buffer} = WriteBuffer.start_link(name: :buffer_test, backend: backend)
+
+      cast_value = fn
+        "invalid" -> 0
+        value -> value
+      end
+
+      buffer = [
+        %TelemetryUI.Event{
+          value: "invalid",
+          time: ~U[2020-01-01T00:00:30Z],
+          event_name: "test",
+          tags: %{},
+          report_as: nil,
+          cast_value: cast_value
+        },
+        %TelemetryUI.Event{
+          value: 2,
+          time: ~U[2020-01-01T00:00:30Z],
+          event_name: "test",
+          tags: %{},
+          report_as: nil,
+          cast_value: cast_value
+        }
+      ]
+
+      state = %WriteBuffer.State{buffer: buffer, backend: backend, timer: nil}
+
+      WriteBuffer.handle_info(:tick, state)
+
+      assert_receive {1.0, ~U[2020-01-01T00:00:00Z], "test", %{}, 2, nil}
+    end
+
     test "group buffer with time" do
       backend = %FakeBackend{max_buffer_size: 3, self: self()}
       {:ok, _write_buffer} = WriteBuffer.start_link(name: :buffer_test, backend: backend)

--- a/test/telemetry_ui/write_buffer_test.exs
+++ b/test/telemetry_ui/write_buffer_test.exs
@@ -28,7 +28,7 @@ defmodule TelemetryUI.WriteBufferTest do
   describe "insert/1 " do
     test "insert with flush" do
       backend = %FakeBackend{self: self(), max_buffer_size: 100, flush_interval_ms: 400}
-      {:ok, write_buffer} = WriteBuffer.start_link(name: :buffer_test, backend: backend)
+      {:ok, write_buffer} = WriteBuffer.start_link(name: :flush_test, backend: backend)
 
       event = %TelemetryUI.Event{
         value: 1,
@@ -63,7 +63,7 @@ defmodule TelemetryUI.WriteBufferTest do
 
     test "resilient to invalid event" do
       backend = %FakeBackend{max_buffer_size: 3, self: self()}
-      {:ok, _write_buffer} = WriteBuffer.start_link(name: :buffer_test, backend: backend)
+      {:ok, _write_buffer} = WriteBuffer.start_link(name: :resilient_test, backend: backend)
 
       buffer = [
         %TelemetryUI.Event{
@@ -92,7 +92,7 @@ defmodule TelemetryUI.WriteBufferTest do
 
     test "cast_value event" do
       backend = %FakeBackend{max_buffer_size: 3, self: self()}
-      {:ok, _write_buffer} = WriteBuffer.start_link(name: :buffer_test, backend: backend)
+      {:ok, _write_buffer} = WriteBuffer.start_link(name: :cast_value_test, backend: backend)
 
       cast_value = fn
         "invalid" -> 0
@@ -127,7 +127,7 @@ defmodule TelemetryUI.WriteBufferTest do
 
     test "group buffer with time" do
       backend = %FakeBackend{max_buffer_size: 3, self: self()}
-      {:ok, _write_buffer} = WriteBuffer.start_link(name: :buffer_test, backend: backend)
+      {:ok, _write_buffer} = WriteBuffer.start_link(name: :group_buffer_test, backend: backend)
 
       buffer = [
         %TelemetryUI.Event{
@@ -164,7 +164,7 @@ defmodule TelemetryUI.WriteBufferTest do
 
     test "group buffer with names" do
       backend = %FakeBackend{max_buffer_size: 3, self: self()}
-      {:ok, _write_buffer} = WriteBuffer.start_link(name: :buffer_test, backend: backend)
+      {:ok, _write_buffer} = WriteBuffer.start_link(name: :group_buffer_name_test, backend: backend)
       now = DateTime.utc_now()
 
       buffer = [


### PR DESCRIPTION
**Ecto** emits a `telemetry` event with a value of `nil` on `queue_time` 😢 This library assumes that the aggregated values are numbers (float or integer). With the new `cast_value` in `reporter_options` we can specify a function that transform the value into a number. The event without a valid value will be discarded instead of crashing the `WriteBuffer` module.