### PR TITLE
Use name instead of event_name in metric uniqueness in Reporter

### DIFF
--- a/lib/telemetry_ui.ex
+++ b/lib/telemetry_ui.ex
@@ -60,7 +60,7 @@ defmodule TelemetryUI do
       |> Enum.flat_map(& &1.metrics)
       |> Enum.map(&Map.get(&1, :telemetry_metric))
       |> Enum.reject(&is_nil/1)
-      |> Enum.uniq_by(&{&1.event_name, &1.tags, TelemetryUI.Event.cast_report_as(&1)})
+      |> Enum.uniq_by(&{&1.name, &1.tags, TelemetryUI.Event.cast_report_as(&1)})
 
     children = [
       {TelemetryUI.Config, config: state, name: config_name(state.name)}


### PR DESCRIPTION
Instead of using the `event_name` as a unique_identifier when determining when event is unique, we change it so that it now uses the `name`. The change is needed since in certain case we want to measure the same event_name in multiple ways. This happens when using the keep or old function to discard some events. For example, in the telemetry_metrics hexdoc we have this:

```elixir
distribution(
  "http.client.request.duration",
  event_name: [:http_client, :request, :stop],
  drop: &(match?(%{name: :fast_client}, &1))
)

distribution(
  "http.fast.client.request.duration",
  event_name: [:http_client, :request, :stop],
  keep: &(match?(%{name: :fast_client}, &1))
)
```

As we can see, the same event_name is used twice which would be merged together at the moment. Since we need to log them individually, we need to use the `name` instead of `event_name`