### PR TITLE
Update MyApp.Repo.Migrations.AddTelemetryUIEventsTable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Open the generated migration in your editor and call the up and down functions o
 defmodule MyApp.Repo.Migrations.AddTelemetryUIEventsTable do
   use Ecto.Migration
 
+  @disable_migration_lock true
+  @disable_ddl_transaction true
+
   def up do
     TelemetryUI.Backend.EctoPostgres.Migrations.up()
   end


### PR DESCRIPTION
Update migration code in README, otherwise it will result with following error when executing migration

```
** (Postgrex.Error) ERROR 25001 (active_sql_transaction) DROP INDEX CONCURRENTLY cannot run inside a transaction block
```