### PR TITLE
fix: average calculation on conflict

### DIFF
--- a/lib/telemetry_ui/backend/ecto_postgres.ex
+++ b/lib/telemetry_ui/backend/ecto_postgres.ex
@@ -42,7 +42,7 @@ defmodule TelemetryUI.Backend.EctoPostgres do
         DO UPDATE SET
           max_value = GREATEST(telemetry_ui_events.max_value, EXCLUDED.value),
           min_value = LEAST(telemetry_ui_events.min_value, EXCLUDED.value),
-          value = ROUND((telemetry_ui_events.value + EXCLUDED.value)::numeric / 2, 4),
+          value = ROUND(((telemetry_ui_events.value * telemetry_ui_events.count) + (EXCLUDED.value * EXCLUDED.count))::numeric / (telemetry_ui_events.count + EXCLUDED.count), 4),
           count = telemetry_ui_events.count + EXCLUDED.count
         """,
         [entry.value, entry.date, entry.name, entry.tags, entry.count, entry.min_value, entry.max_value],

--- a/test/telemetry_ui/ecto_postgres_test.exs
+++ b/test/telemetry_ui/ecto_postgres_test.exs
@@ -107,7 +107,7 @@ defmodule TelemetryUI.EctoPostgresTest do
 
       [event] = backend.repo.all(Entry)
 
-      assert event.value === 15.0
+      assert event.value === 16.6667
       assert event.tags === %{}
       assert event.count === 6
       assert event.date === ~U[2022-02-10T00:00:00Z]
@@ -136,7 +136,7 @@ defmodule TelemetryUI.EctoPostgresTest do
 
       [event] = backend.repo.all(Entry)
 
-      assert event.value === 15.0
+      assert event.value === 16.6667
       assert event.min_value === 10.0
       assert event.max_value === 20.0
       assert event.tags === %{}


### PR DESCRIPTION
When the ON CONFLICT clause in the postgres query get's trigerred, we
use to make an average of the old and new data without considering the
count.

We now use weighted average to have mathematically correct averages
