### PR TITLE
feat: add source to insert events query

### DIFF
--- a/lib/telemetry_ui/backend/ecto_postgres.ex
+++ b/lib/telemetry_ui/backend/ecto_postgres.ex
@@ -46,6 +46,7 @@ defmodule TelemetryUI.Backend.EctoPostgres do
           count = telemetry_ui_events.count + EXCLUDED.count
         """,
         [entry.value, entry.date, entry.name, entry.tags, entry.count, entry.min_value, entry.max_value],
+        source: Entry.__schema__(:source),
         log: backend.verbose,
         telemetry_prefix: backend.telemetry_prefix,
         telemetry_options: backend.telemetry_options


### PR DESCRIPTION
The query used to insert events into postgres uses raw SQL which means
ecto isn't able to infer the source (The database table) used for the
query. This source value is quite useful to filter or group metrics and
traces to easily identify which table is hot
